### PR TITLE
Pytest workflow - fix Python version matrix

### DIFF
--- a/.github/workflows/nightly-pytest.yml
+++ b/.github/workflows/nightly-pytest.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10, 3.11]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
 
       - uses: actions/checkout@v3


### PR DESCRIPTION
Fixed an issue where the Python version matrix was not being passed into the job correctly as it was not comprised of strings.