### PR TITLE
17585: Removes extensions from artifact upload names

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -43,7 +43,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh ${{ needs.get-howso-engine-py-details.outputs.run-type }} download -D hse -R "howsoai/howso-engine-py" -p "howso_engine-*-py3-none-any.whl" "${{ needs.get-howso-engine-py-details.outputs.run-id }}"
+          gh ${{ needs.get-howso-engine-py-details.outputs.run-type }} download -D hse -R "howsoai/howso-engine-py" -p "howso_engine-*-py3-none-any" "${{ needs.get-howso-engine-py-details.outputs.run-id }}"
           # Needed because release/non-release downloads are different structure
           cd hse && if [ ! -f howso_engine-*.whl ]; then mv howso_engine-*.whl ./tmp && mv ./tmp/howso_engine-*.whl ./; fi
 
@@ -52,7 +52,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh ${{ needs.get-amalgam-lang-py-details.outputs.run-type }} download -D amlg -R "howsoai/amalgam-lang-py" -p "amalgam_lang-*-py3-none-any.whl" "${{ needs.get-amalgam-lang-py-details.outputs.run-id }}"
+          gh ${{ needs.get-amalgam-lang-py-details.outputs.run-type }} download -D amlg -R "howsoai/amalgam-lang-py" -p "amalgam_lang-*-py3-none-any" "${{ needs.get-amalgam-lang-py-details.outputs.run-id }}"
           # Needed because release/non-release downloads are different structure
           cd amlg && if [ ! -f amalgam_lang-*.whl ]; then mv amalgam_lang-*.whl ./tmp && mv ./tmp/amalgam_lang-*.whl ./; fi
 


### PR DESCRIPTION
Artifact upload names are essentially folders, not single artifacts. So the upload names should not have extensions in the name.