### PR TITLE
19419: Improves auto analyze threshold for TS cartpole

### DIFF
--- a/howso_engine_rl_recipes/cart_pole/agent/ts_agent.py
+++ b/howso_engine_rl_recipes/cart_pole/agent/ts_agent.py
@@ -125,7 +125,7 @@ class TimeSeriesAgent(BaseAgent[np.ndarray, int]):
         self.trainee = engine.Trainee(features=self.features)
         self.trainee.set_auto_analyze_params(
             auto_analyze_enabled=True,
-            analyze_threshold=1_000,
+            analyze_threshold=2_000,
             auto_analyze_limit_size=30_000,
         )
         if self.seed is not None:


### PR DESCRIPTION
Seems that due to the extra features of time series, having it auto-analyze too early causes the model to analyze on early/poorly played games. Bumping up the auto_analyze threshold allows the exploration aspect to train on more 'better' games prior to analyzing, so that it can continue to improve at a faster rate and win faster than before.