### PR TITLE
23054: Fixes to RL recipes

### DIFF
--- a/howso_engine_rl_recipes/cart_pole/agent/basic_agent.py
+++ b/howso_engine_rl_recipes/cart_pole/agent/basic_agent.py
@@ -74,7 +74,8 @@ class BasicAgent(BaseAgent[np.ndarray, int]):
         self.trainee = engine.Trainee(features=self.features)
         self.trainee.set_auto_analyze_params(
             auto_analyze_enabled=True,
-            context_features=self.context_features + self.action_features
+            context_features=self.context_features + self.action_features,
+            rebalance_features=self.goal_features
         )
         self.goal_map = dict(zip(self.goal_features, [{"goal": "max"}]))
 

--- a/howso_engine_rl_recipes/cart_pole/agent/ts_agent.py
+++ b/howso_engine_rl_recipes/cart_pole/agent/ts_agent.py
@@ -125,7 +125,8 @@ class TimeSeriesAgent(BaseAgent[np.ndarray, int]):
         self.trainee = engine.Trainee(features=self.features)
         self.trainee.set_auto_analyze_params(
             auto_analyze_enabled=True,
-            context_features=self.context_features + self.lag_features + self.action_features
+            context_features=self.context_features + self.lag_features + self.action_features,
+            rebalance_features=self.goal_features
         )
         self.goal_map = dict(zip(self.goal_features, [{"goal": "max"}]))
 

--- a/howso_engine_rl_recipes/simulation.py
+++ b/howso_engine_rl_recipes/simulation.py
@@ -191,6 +191,9 @@ class Simulation:
         """Run a single simulation of a game."""
         # Import locally so loggers are created after setup
         GameClass = import_game(game_type)
+        # force a random seed for every iteration
+        if "seed" not in kwargs:
+            kwargs["seed"] = (1 + iteration) * int(100000 * np.random.rand())
         with GameClass(**kwargs) as game:
             result = game.play()
         return result

--- a/tests/test_cart_pole.py
+++ b/tests/test_cart_pole.py
@@ -8,11 +8,12 @@ logger = logging.getLogger("howso.rl.tests")
 
 @pytest.mark.regression
 @pytest.mark.parametrize('agent_type, iterations, max_avg_rounds', [
-    ('basic', 4, 600),
+    ('basic', 6, 600),
 ])
 def test_agents_regression(agent_type, iterations, max_avg_rounds):
     """Test cart pole is solved by all agent types."""
-    sim = Simulation(iterations=iterations, max_workers=iterations)
+    max_workers = int(cpu_count() / 2 - 1)
+    sim = Simulation(iterations=iterations, max_workers=max_workers)
     results = sim.run(game_type=GameType.CART_POLE, agent_type=agent_type,
                       max_rounds=600)
 
@@ -37,7 +38,8 @@ def test_agents_regression(agent_type, iterations, max_avg_rounds):
 ])
 def test_agents_experimental(agent_type, iterations, max_avg_rounds):
     """Test cart pole is solved by all agent types."""
-    sim = Simulation(iterations=iterations, max_workers=iterations)
+    max_workers = int(cpu_count() / 2 - 1)
+    sim = Simulation(iterations=iterations, max_workers=max_workers)
     results = sim.run(game_type=GameType.CART_POLE, agent_type=agent_type,
                       max_rounds=1000)
 


### PR DESCRIPTION
- use rebalance features in all recipes
- enforce a random seed for every iteration if not provided
- make number of workers logic consistent for all recipes