### PR TITLE
22817: Update RL tests for stability

### DIFF
--- a/howso_engine_rl_recipes/wafer_thin_mint/agent/basic_agent.py
+++ b/howso_engine_rl_recipes/wafer_thin_mint/agent/basic_agent.py
@@ -63,10 +63,7 @@ class BasicAgent(BaseAgent[int, int]):
 
     def act(self, observation, round_num, step) -> int:
         """React to the observation to get the action."""
-        # Note: setting desired_conviction to 2 will cause the average score to
-        # be notably higher but will result in occasional failures to learn
-        # TODO:22817 - lower conviction to 1
-        desired_conviction = 2
+        desired_conviction = 1
 
         details = {}
         if self.explanation_level >= 2:

--- a/tests/test_cart_pole.py
+++ b/tests/test_cart_pole.py
@@ -9,7 +9,7 @@ logger = logging.getLogger("howso.rl.tests")
 
 @pytest.mark.regression
 @pytest.mark.parametrize('agent_type, iterations, max_avg_rounds', [
-    ('basic', 6, 600),
+    ('basic', 12, 600),
 ])
 def test_agents_regression(agent_type, iterations, max_avg_rounds):
     """Test cart pole is solved by all agent types."""
@@ -35,7 +35,7 @@ def test_agents_regression(agent_type, iterations, max_avg_rounds):
 
 @pytest.mark.experimental
 @pytest.mark.parametrize('agent_type, iterations, max_avg_rounds', [
-    ('time-series', 4, 1000),
+    ('time-series', 8, 1000),
 ])
 def test_agents_experimental(agent_type, iterations, max_avg_rounds):
     """Test cart pole is solved by all agent types."""
@@ -54,6 +54,6 @@ def test_agents_experimental(agent_type, iterations, max_avg_rounds):
     assert len(results['runs']) == iterations
 
     metrics = results['metrics']
-    assert metrics['total-won'] >= 2
+    assert metrics['total-won'] >= 4
     assert metrics['average-rounds-to-win'] < max_avg_rounds
     assert metrics['average-win-high-score'] >= 300

--- a/tests/test_wtm.py
+++ b/tests/test_wtm.py
@@ -25,7 +25,7 @@ def test_wafer_thin_mint(agent_type, iterations):
 
     metrics = results['metrics']
     assert metrics['percent-won'] >= 60
-    assert metrics['average-win-high-score'] > 8.9
+    assert metrics['average-win-high-score'] >= 8.7
     assert metrics['average-rounds-to-win'] > 2
 
     # Make sure there are at least 2 cases or games, which is the minimum to


### PR DESCRIPTION
increase the number of games for cartpole due to faster synth, and update avg threshold for wtm